### PR TITLE
DPT-429 fix elastic search returns wrong total

### DIFF
--- a/basestar-storage-elasticsearch/src/main/java/io/basestar/storage/elasticsearch/ElasticsearchUtils.java
+++ b/basestar-storage-elasticsearch/src/main/java/io/basestar/storage/elasticsearch/ElasticsearchUtils.java
@@ -150,18 +150,19 @@ public class ElasticsearchUtils {
 
     public static QueryBuilder pagingQueryBuilder(final LinkableSchema schema, final List<Sort> sort, final Page.Token token) {
 
-        final List<Object> values = KeysetPagingUtils.keysetValues(schema, sort, token);
+        Map<String, List<Object>> stringListMap = KeysetPagingUtils.countPreservingKeysetValues(schema, sort, token);
+        final List<Object> sorting = stringListMap.get("sort");
         final BoolQueryBuilder outer = QueryBuilders.boolQuery();
         for(int i = 0; i < sort.size(); ++i) {
             if(i == 0) {
-                outer.should(pagingRange(sort.get(i), values.get(i)));
+                outer.should(pagingRange(sort.get(i), sorting.get(i)));
             } else {
                 final BoolQueryBuilder inner = QueryBuilders.boolQuery();
                 for (int j = 0; j < i; ++j) {
                     final Name name = sort.get(j).getName();
-                    inner.must(QueryBuilders.termQuery(name.toString(), values.get(j)));
+                    inner.must(QueryBuilders.termQuery(name.toString(), sorting.get(j)));
                 }
-                inner.must(pagingRange(sort.get(i), values.get(i)));
+                inner.must(pagingRange(sort.get(i), sorting.get(i)));
                 outer.should(inner);
             }
         }

--- a/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
+++ b/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
@@ -40,9 +40,7 @@ import org.apache.commons.csv.CSVParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.*;
@@ -264,14 +262,14 @@ public abstract class TestStorage {
         for(int i = 0; i != 10; ++i) {
             final Page<Map<String, Object>> page = pager.page(ImmutableSet.of(Page.Stat.TOTAL, Page.Stat.APPROX_TOTAL), token,10).join();
             final Page.Stats stats = page.getStats();
-//            if(stats != null) {
-//                if(stats.getTotal() != null) {
-//                    assertEquals(100, stats.getTotal());
-//                }
-//                if(stats.getApproxTotal() != null) {
-//                    assertEquals(100, stats.getApproxTotal());
-//                }
-//            }
+               if(stats != null) {
+                   if(stats.getTotal() != null) {
+                       assertEquals(100, stats.getTotal());
+                   }
+                   if(stats.getApproxTotal() != null) {
+                       assertEquals(100, stats.getApproxTotal());
+                   }
+               }
             page.forEach(object -> results.add(Instance.getId(object)));
             token = page.getPaging();
         }


### PR DESCRIPTION
ElasticSearch queries returns smaller total count on every page therefore first total count is added into paging token and parsed on every new page