### PR TITLE
Change elastic search paging total to always return the original full…

### DIFF
--- a/basestar-storage-elasticsearch/src/main/java/io/basestar/storage/elasticsearch/query/ESQueryStage.java
+++ b/basestar-storage-elasticsearch/src/main/java/io/basestar/storage/elasticsearch/query/ESQueryStage.java
@@ -13,6 +13,7 @@ import io.basestar.storage.elasticsearch.expression.ESAggregate;
 import io.basestar.storage.elasticsearch.expression.ESAggregateVisitor;
 import io.basestar.storage.elasticsearch.expression.ESExpressionVisitor;
 import io.basestar.storage.elasticsearch.mapping.Mappings;
+import io.basestar.storage.util.CountPreservingTokenInfo;
 import io.basestar.storage.util.KeysetPagingUtils;
 import io.basestar.util.Immutable;
 import io.basestar.util.Name;
@@ -79,7 +80,7 @@ public interface ESQueryStage {
         public ESQueryStage filter(final Expression filter) {
 
             final Expression newFilter;
-            if(this.filter != null) {
+            if (this.filter != null) {
                 newFilter = new And(this.filter, filter);
             } else {
                 newFilter = filter;
@@ -117,13 +118,13 @@ public interface ESQueryStage {
             final SearchRequest request = new SearchRequest(strategy.index(schema));
             final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
             final QueryBuilder basicQuery;
-            if(filter != null) {
+            if (filter != null) {
                 basicQuery = new ESExpressionVisitor().visit(filter);
             } else {
                 basicQuery = null;
             }
             final QueryBuilder query;
-            if(count != 0) {
+            if (count != 0) {
                 final List<Sort> normalizedSort = KeysetPagingUtils.normalizeSort(schema, sort);
                 normalizedSort.forEach(s -> sourceBuilder.sort(ElasticsearchUtils.sort(s)));
                 if (token == null) {
@@ -165,14 +166,23 @@ public interface ESQueryStage {
                 last = mappings.fromSource(hit.getSourceAsMap());
                 results.add(last);
             }
-            final long total = hits.getTotalHits().value;
+            final long total = getTotal(token, hits);
             final Page.Token newPaging;
             if (total > results.size() && last != null) {
-                newPaging = KeysetPagingUtils.keysetPagingToken(schema, normalizedSort, last);
+                final Page.Token sortingToken = KeysetPagingUtils.keysetPagingToken(schema, normalizedSort, last);
+                newPaging = KeysetPagingUtils.countPreservingToken(sortingToken, total);
             } else {
                 newPaging = null;
             }
             return new Page<>(results, newPaging, Page.Stats.fromTotal(total));
+        }
+
+        private long getTotal(Page.Token token, SearchHits hits) {
+            if (token != null) {
+                CountPreservingTokenInfo countPreservingTokenInfo = KeysetPagingUtils.countPreservingTokenInfo(token);
+                return countPreservingTokenInfo.getTotal();
+            }
+           return hits.getTotalHits().value;
         }
     }
 
@@ -209,7 +219,7 @@ public interface ESQueryStage {
         @Override
         public ESQueryStage sort(final List<Sort> sort) {
 
-            if(sort.stream().allMatch(s -> group.contains(s.getName().toString()))) {
+            if (sort.stream().allMatch(s -> group.contains(s.getName().toString()))) {
                 return new Agg(source, group, sort, expressions);
             } else {
                 throw new UnsupportedOperationException("Sorting of aggregates by non-group terms is not supported");
@@ -225,7 +235,7 @@ public interface ESQueryStage {
         private CompositeValuesSourceBuilder<?> groupSource(final String name) {
 
             final TypedExpression<?> expr = expressions.get(name);
-            if(expr.getExpression() instanceof NameConstant) {
+            if (expr.getExpression() instanceof NameConstant) {
                 final Name field = ((NameConstant) expr.getExpression()).getName();
                 return new TermsValuesSourceBuilder(name).field(field.toString())
                         .missingBucket(true).order(order(name));
@@ -236,7 +246,7 @@ public interface ESQueryStage {
 
         private SortOrder order(final String name) {
 
-            if(sort == null) {
+            if (sort == null) {
                 return SortOrder.ASC;
             } else {
                 return sort.stream().filter(v -> v.getName().toString().equals(name))
@@ -250,7 +260,7 @@ public interface ESQueryStage {
             final ESAggregateVisitor aggVisitor = new ESAggregateVisitor(inference);
             final Map<String, ESAggregate> aggs = new HashMap<>();
             expressions.forEach((k, expr) -> {
-                if(!group.contains(k)) {
+                if (!group.contains(k)) {
                     aggs.put(k, aggVisitor.visit(expr.getExpression()));
                 }
             });
@@ -262,7 +272,7 @@ public interface ESQueryStage {
             final List<AggregationBuilder> aggs = new ArrayList<>();
             final Set<String> seen = new HashSet<>();
             aggs().values().forEach(agg -> agg.builders().forEach(builder -> {
-                if(!seen.contains(builder.getName())) {
+                if (!seen.contains(builder.getName())) {
                     seen.add(builder.getName());
                     aggs.add(builder);
                 }
@@ -272,7 +282,7 @@ public interface ESQueryStage {
 
         private List<AggregationBuilder> aggs(final Set<Page.Stat> stats, final Page.Token token, final int count) {
 
-            if(!group.isEmpty()) {
+            if (!group.isEmpty()) {
                 final List<CompositeValuesSourceBuilder<?>> sources = new ArrayList<>();
                 group.forEach(g -> sources.add(groupSource(g)));
                 final CompositeAggregationBuilder agg = AggregationBuilders.composite("group", sources);
@@ -303,11 +313,11 @@ public interface ESQueryStage {
         @Override
         public Page<Map<String, Object>> page(final Mappings mappings, final Set<Page.Stat> stats, final Page.Token token, final int count, final SearchResponse response) {
 
-            if(!group.isEmpty()) {
+            if (!group.isEmpty()) {
                 final List<Map<String, Object>> results = new ArrayList<>();
                 final CompositeAggregation group = response.getAggregations().get("group");
                 final Map<String, ESAggregate> aggs = aggs();
-                for(final CompositeAggregation.Bucket bucket : group.getBuckets()) {
+                for (final CompositeAggregation.Bucket bucket : group.getBuckets()) {
                     final Map<String, Object> result = new HashMap<>(bucket.getKey());
                     aggs.forEach((key, agg) -> result.put(key, agg.read(bucket)));
                     results.add(mappings.fromSource(result));

--- a/basestar-storage/src/main/java/io/basestar/storage/exception/PagingTokenSyntaxException.java
+++ b/basestar-storage/src/main/java/io/basestar/storage/exception/PagingTokenSyntaxException.java
@@ -1,0 +1,23 @@
+package io.basestar.storage.exception;
+
+import io.basestar.exception.ExceptionMetadata;
+import io.basestar.exception.HasExceptionMetadata;
+
+public class PagingTokenSyntaxException extends RuntimeException implements HasExceptionMetadata {
+
+    public static final int STATUS = 400;
+
+    public static final String CODE = "CorruptedToken";
+
+    public PagingTokenSyntaxException(final String message) {
+        super(message);
+    }
+
+    @Override
+    public ExceptionMetadata getMetadata() {
+        return new ExceptionMetadata()
+                .setStatus(STATUS)
+                .setCode(CODE)
+                .setMessage(getMessage());
+    }
+}

--- a/basestar-storage/src/main/java/io/basestar/storage/util/CountPreservingTokenInfo.java
+++ b/basestar-storage/src/main/java/io/basestar/storage/util/CountPreservingTokenInfo.java
@@ -1,0 +1,11 @@
+package io.basestar.storage.util;
+
+import io.basestar.util.Page;
+import lombok.Data;
+
+@Data
+public class CountPreservingTokenInfo {
+
+    private final Long total;
+    private final Page.Token token;
+}

--- a/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
+++ b/basestar-storage/src/test/java/io/basestar/storage/TestStorage.java
@@ -40,9 +40,7 @@ import org.apache.commons.csv.CSVParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.io.*;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.*;
@@ -264,14 +262,14 @@ public abstract class TestStorage {
         for(int i = 0; i != 10; ++i) {
             final Page<Map<String, Object>> page = pager.page(ImmutableSet.of(Page.Stat.TOTAL, Page.Stat.APPROX_TOTAL), token,10).join();
             final Page.Stats stats = page.getStats();
-//            if(stats != null) {
-//                if(stats.getTotal() != null) {
-//                    assertEquals(100, stats.getTotal());
-//                }
-//                if(stats.getApproxTotal() != null) {
-//                    assertEquals(100, stats.getApproxTotal());
-//                }
-//            }
+               if(stats != null) {
+                   if(stats.getTotal() != null) {
+                       assertEquals(100, stats.getTotal());
+                   }
+                   if(stats.getApproxTotal() != null) {
+                       assertEquals(100, stats.getApproxTotal());
+                   }
+               }
             page.forEach(object -> results.add(Instance.getId(object)));
             token = page.getPaging();
         }

--- a/basestar-storage/src/test/java/io/basestar/storage/util/TestKeysetPagingUtils.java
+++ b/basestar-storage/src/test/java/io/basestar/storage/util/TestKeysetPagingUtils.java
@@ -5,15 +5,21 @@ import io.basestar.schema.Instance;
 import io.basestar.schema.Namespace;
 import io.basestar.schema.ObjectSchema;
 import io.basestar.storage.TestStorage;
+import io.basestar.storage.exception.PagingTokenSyntaxException;
 import io.basestar.util.ISO8601;
 import io.basestar.util.Name;
+import io.basestar.util.Page;
 import io.basestar.util.Sort;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class TestKeysetPagingUtils {
 
@@ -28,5 +34,45 @@ class TestKeysetPagingUtils {
         Instance.setCreated(object, ISO8601.now());
 
         KeysetPagingUtils.keysetPagingToken(schema, ImmutableList.of(Sort.asc(Name.of("created"))), object);
+    }
+
+    @Test
+    void testCountPreservingToken() throws IOException {
+
+        final Namespace namespace = Namespace.load(TestStorage.class.getResource("schema.yml"));
+
+        final ObjectSchema schema = namespace.requireObjectSchema("DateSort");
+
+        final Map<String, Object> object = new HashMap<>();
+        final Instant now = ISO8601.now();
+        Instance.setCreated(object, now);
+        final ImmutableList<Sort> sortingInfo = ImmutableList.of(Sort.asc(Name.of("created")));
+
+        final Page.Token originalToken = KeysetPagingUtils.keysetPagingToken(schema, sortingInfo, object);
+        final  Page.Token countPreservingToken = KeysetPagingUtils.countPreservingToken(originalToken, 98);
+        final CountPreservingTokenInfo countPreservingTokenInfo = KeysetPagingUtils.countPreservingTokenInfo(countPreservingToken);
+        final List<Object> sort = KeysetPagingUtils.keysetValues(schema, sortingInfo, countPreservingTokenInfo.getToken());
+
+        assertEquals(98, countPreservingTokenInfo.getTotal());
+        assertEquals(originalToken, countPreservingTokenInfo.getToken());
+        assertEquals(1, sort.size());
+        assertEquals(now, sort.get(0));
+    }
+
+
+    @Test
+    void testMismatchingTokenDeserialization() throws IOException {
+
+        final Namespace namespace = Namespace.load(TestStorage.class.getResource("schema.yml"));
+
+        final ObjectSchema schema = namespace.requireObjectSchema("DateSort");
+
+        final Map<String, Object> object = new HashMap<>();
+        final Instant now = ISO8601.now();
+        Instance.setCreated(object, now);
+        final ImmutableList<Sort> sortingInfo = ImmutableList.of(Sort.asc(Name.of("created")));
+
+        final Page.Token pagingToken = KeysetPagingUtils.keysetPagingToken(schema, sortingInfo, object);
+        assertThrows(PagingTokenSyntaxException.class, () -> KeysetPagingUtils.countPreservingTokenInfo(pagingToken));
     }
 }


### PR DESCRIPTION
… total

ElasticSearch queries returns smaller total count on every page therefore first total count is added into paging token and parsed on every new page
Changes made:
* introduced PagingTokenSyntaxException
* introduced countPreserving token that wraps other token